### PR TITLE
Ensure entityService.find() works regardless of pagination setting

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -38,12 +38,13 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
     const { errorMessage, entity } = this.configuration;
     try {
       const result = await this.entityService.find({
-        query: { [entity]: apiKey, $limit: 1 }
+        query: { [entity]: apiKey, $limit: 1 },
+        paginate: false
       });
-      if (result.total === 0) {
+      if (result.length === 0) {
         throw new NotAuthenticated(errorMessage);
       }
-      return result.data[0];
+      return result[0];
     } catch (error) {
       throw new NotAuthenticated(errorMessage);
     }


### PR DESCRIPTION
When using a service to look up API keys, if Feathers or that service are not set up with pagination enabled by default, the `findEntity()` function dies with "Cannot read property '0' of undefined".

My proposed fix manually disables pagination in the `entityService.find()` call ([as per Feathers documentation](https://docs.feathersjs.com/api/databases/common.html#pagination)), working with a normal array output from the `find()` call instead.